### PR TITLE
fix(TRV13): Add transaction_id to confirm payments and update on_select/select generators

### DIFF
--- a/src/config/mock-config/TRV13/2.0.0/confirm/confirm_1/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/confirm/confirm_1/generator.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from "uuid";
+
 export async function confirmDefaultGenerator(
   existingPayload: any,
   sessionData: any
@@ -5,7 +7,14 @@ export async function confirmDefaultGenerator(
   const payments =
     sessionData?.on_init_payments?.[0]?.map((payment: any) => {
       if (payment.type === "PRE-ORDER") {
-        return { ...payment, status: "PAID" };
+        return { 
+          ...payment, 
+          status: "PAID",
+          params: {
+            ...payment.params,
+            transaction_id: `payment-utr-${uuidv4().slice(0, 8)}`
+          }
+        };
       } else {
         return { ...payment, status: "NOT-PAID" };
       }

--- a/src/config/mock-config/TRV13/2.0.0/confirm/confirm_3/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/confirm/confirm_3/generator.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from "uuid";
+
 export async function confirmDefaultGenerator(
   existingPayload: any,
   sessionData: any
@@ -5,7 +7,14 @@ export async function confirmDefaultGenerator(
   const payments =
     sessionData?.on_init_payments?.[0]?.map((payment: any) => {
       if (payment.type === "PRE-ORDER") {
-        return { ...payment, status: "PAID" };
+        return { 
+          ...payment, 
+          status: "PAID",
+          params: {
+            ...payment.params,
+            transaction_id: `payment-utr-${uuidv4().slice(0, 8)}`
+          }
+        };
       } else {
         return { ...payment, status: "NOT-PAID" };
       }

--- a/src/config/mock-config/TRV13/2.0.0/confirm/confirm_4/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/confirm/confirm_4/generator.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from "uuid";
+
 export async function confirmDefaultGenerator(
   existingPayload: any,
   sessionData: any
@@ -5,7 +7,14 @@ export async function confirmDefaultGenerator(
   const payments =
     sessionData?.on_init_payments?.[0]?.map((payment: any) => {
       if (payment.type === "PRE-ORDER") {
-        return { ...payment, status: "PAID" };
+        return { 
+          ...payment, 
+          status: "PAID",
+          params: {
+            ...payment.params,
+            transaction_id: `payment-utr-${uuidv4().slice(0, 8)}`
+          }
+        };
       } else {
         return { ...payment, status: "NOT-PAID" };
       }

--- a/src/config/mock-config/TRV13/2.0.0/confirm/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/confirm/generator.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from "uuid";
+
 export async function confirmDefaultGenerator(
   existingPayload: any,
   sessionData: any
@@ -5,7 +7,14 @@ export async function confirmDefaultGenerator(
   const payments =
     sessionData?.on_init_payments?.[0]?.map((payment: any) => {
       if (payment.type === "PRE-ORDER") {
-        return { ...payment, status: "PAID" };
+        return { 
+          ...payment, 
+          status: "PAID",
+          params: {
+            ...payment.params,
+            transaction_id: `payment-utr-${uuidv4().slice(0, 8)}`
+          }
+        };
       } else {
         return { ...payment, status: "NOT-PAID" };
       }

--- a/src/config/mock-config/TRV13/2.0.0/on_select/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/on_select/generator.ts
@@ -9,90 +9,88 @@ export async function onSelectDefaultGenerator(
     sessionData?.select_provider_id ?? "P1";
 
   const selectItems = sessionData?.select_items[0] ?? [];
-  const on_search_1_item = sessionData?.on_search_1_items[0] ?? [];
+  const catalogItems = sessionData?.on_search_1_items[0] ?? [];
+
+  // Find selected item in catalog to get actual prices
+  const selectedItemId = selectItems[0]?.id;
+  const catalogItem = catalogItems.find((item: any) => item.id === selectedItemId) ?? catalogItems[0];
+  
+  // Get item price from catalog
+  const itemPrice = Number(catalogItem?.price?.value ?? "2000.00");
+  const quantity = selectItems[0]?.quantity?.selected?.count ?? 1;
+  
+  // Get selected addon and its price from catalog
+  const selectedAddonId = selectItems[0]?.add_ons?.[0]?.id;
+  const catalogAddon = catalogItem?.add_ons?.find((a: any) => a.id === selectedAddonId);
+  const addonPrice = Number(catalogAddon?.price?.value ?? "500.00");
+  const addonName = catalogAddon?.descriptor?.short_desc ?? "Accommodation with all meals included";
+  
+  // Calculate totals
+  const baseItemTotal = itemPrice * quantity;
+  const totalWithAddons = baseItemTotal + addonPrice;
+  const serviceTax = Math.round(totalWithAddons * 0.09);
+  const gst = Math.round(totalWithAddons * 0.12);
+  const totalPrice = totalWithAddons + serviceTax + gst;
 
   existingPayload.message.order.items = selectItems.map((item: any) => ({
     id: item.id,
     add_ons: item.add_ons,
-    payment_ids: [on_search_1_item[0]?.payment_ids[0]],
+    payment_ids: [catalogItems[0]?.payment_ids?.[0]],
   }));
 
   existingPayload.message.order.quote = {
     price: {
       currency: "INR",
-      value: "3025.00",
+      value: totalPrice.toFixed(2),
     },
     breakup: [
       {
         item: {
-          id: selectItems[0]?.id ?? "Accommodation-1",
+          id: selectedItemId ?? "Accommodation-1",
           quantity: selectItems[0]?.quantity ?? {
             selected: {
-              count: 2,
+              count: 1,
             },
           },
           price: {
             currency: "INR",
-            value: "2000.00",
+            value: itemPrice.toFixed(2),
           },
           add_ons: [
             {
-              id: selectItems[0]?.add_ons[0]?.id ?? "full-board",
+              id: selectedAddonId ?? "full-board",
               price: {
                 currency: "INR",
-                value: "500.00",
+                value: addonPrice.toFixed(2),
               },
             },
           ],
         },
-        title:
-          "Deluxe Room accommodation with all meals included (breakfast, lunch, and dinner)",
+        title: catalogItem?.descriptor?.name ?? "Deluxe Room accommodation with all meals included",
         price: {
           currency: "INR",
-          value: "300.00",
+          value: totalWithAddons.toFixed(2),
         },
       },
       {
         title: "Service Tax @ 9%",
         price: {
           currency: "INR",
-          value: "225",
+          value: serviceTax.toString(),
         },
       },
       {
         title: "GST @ 12%",
         price: {
           currency: "INR",
-          value: "400",
+          value: gst.toString(),
         },
       },
     ],
     ttl: "P1D",
   };
 
-  let totalPrice = 0;
 
-  existingPayload.message.order.quote.breakup.forEach((breakup: any) => {
-    if (breakup.item) {
-      let itemPrice =
-        Number(breakup.item.price.value) *
-        Number(breakup.item.quantity?.selected?.count ?? 1);
-
-      if (breakup.item.add_ons?.length) {
-        itemPrice += breakup.item.add_ons.reduce(
-          (sum: number, addon: any) => sum + Number(addon.price.value),
-          0
-        );
-      }
-
-      breakup.price.value = itemPrice.toString();
-      totalPrice += itemPrice;
-    } else {
-      totalPrice += Number(breakup.price.value);
-    }
-  });
-
-  existingPayload.message.order.quote.price.value = totalPrice.toString();
 
   existingPayload.message.order.payments = [
     {
@@ -174,7 +172,7 @@ export async function onSelectDefaultGenerator(
     },
   ];
 
-  const paymentIds = on_search_1_item[0]?.payment_ids ?? [];
+  const paymentIds = catalogItems[0]?.payment_ids ?? [];
 
   existingPayload.message.order.payments.forEach(
     (payment: any, index: number) => {

--- a/src/config/mock-config/TRV13/2.0.0/on_select/on_select_1/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/on_select/on_select_1/generator.ts
@@ -9,90 +9,88 @@ export async function onSelectDefaultGenerator(
     sessionData?.select_provider_id ?? "P1";
 
   const selectItems = sessionData?.select_items[0] ?? [];
-  const on_search_1_item = sessionData?.on_search_1_items[0] ?? [];
+  const catalogItems = sessionData?.on_search_1_items[0] ?? [];
+
+  // Find selected item in catalog to get actual prices
+  const selectedItemId = selectItems[0]?.id;
+  const catalogItem = catalogItems.find((item: any) => item.id === selectedItemId) ?? catalogItems[0];
+  
+  // Get item price from catalog
+  const itemPrice = Number(catalogItem?.price?.value ?? "2000.00");
+  const quantity = parseInt(selectItems[0]?.quantity?.selected?.count) || 1;
+  
+  // Get selected addon and its price from catalog
+  const selectedAddonId = selectItems[0]?.add_ons?.[0]?.id;
+  const catalogAddon = catalogItem?.add_ons?.find((a: any) => a.id === selectedAddonId);
+  const addonPrice = Number(catalogAddon?.price?.value ?? "500.00");
+  const addonName = catalogAddon?.descriptor?.short_desc ?? "Accommodation with all meals included";
+  
+  // Calculate totals
+  const baseItemTotal = itemPrice * quantity;
+  const totalWithAddons = baseItemTotal + addonPrice;
+  const serviceTax = Math.round(totalWithAddons * 0.09);
+  const gst = Math.round(totalWithAddons * 0.12);
+  const totalPrice = totalWithAddons + serviceTax + gst;
 
   existingPayload.message.order.items = selectItems.map((item: any) => ({
     id: item.id,
     add_ons: item.add_ons,
-    payment_ids: [on_search_1_item[0]?.payment_ids[0]],
+    payment_ids: [catalogItems[0]?.payment_ids?.[0]],
   }));
 
   existingPayload.message.order.quote = {
     price: {
       currency: "INR",
-      value: "3025.00",
+      value: totalPrice.toFixed(2),
     },
     breakup: [
       {
         item: {
-          id: selectItems[0]?.id ?? "Accommodation-1",
-          quantity: selectItems[0]?.quantity ?? {
+          id: selectedItemId ?? "Accommodation-1",
+          quantity: {
             selected: {
-              count: 2,
+              count: quantity,
             },
           },
           price: {
             currency: "INR",
-            value: "2000.00",
+            value: itemPrice.toFixed(2),
           },
           add_ons: [
             {
-              id: selectItems[0]?.add_ons[0]?.id ?? "full-board",
+              id: selectedAddonId ?? "full-board",
               price: {
                 currency: "INR",
-                value: "500.00",
+                value: addonPrice.toFixed(2),
               },
             },
           ],
         },
-        title:
-          "Deluxe Room accommodation with all meals included (breakfast, lunch, and dinner)",
+        title: catalogItem?.descriptor?.name ?? "Deluxe Room accommodation with all meals included",
         price: {
           currency: "INR",
-          value: "300.00",
+          value: totalWithAddons.toFixed(2),
         },
       },
       {
         title: "Service Tax @ 9%",
         price: {
           currency: "INR",
-          value: "225",
+          value: serviceTax.toString(),
         },
       },
       {
         title: "GST @ 12%",
         price: {
           currency: "INR",
-          value: "400",
+          value: gst.toString(),
         },
       },
     ],
     ttl: "P1D",
   };
 
-  let totalPrice = 0;
 
-  existingPayload.message.order.quote.breakup.forEach((breakup: any) => {
-    if (breakup.item) {
-      let itemPrice =
-        Number(breakup.item.price.value) *
-        Number(breakup.item.quantity?.selected?.count ?? 1);
-
-      if (breakup.item.add_ons?.length) {
-        itemPrice += breakup.item.add_ons.reduce(
-          (sum: number, addon: any) => sum + Number(addon.price.value),
-          0
-        );
-      }
-
-      breakup.price.value = itemPrice.toString();
-      totalPrice += itemPrice;
-    } else {
-      totalPrice += Number(breakup.price.value);
-    }
-  });
-
-  existingPayload.message.order.quote.price.value = totalPrice.toString();
 
   existingPayload.message.order.payments = [
     {
@@ -174,7 +172,7 @@ export async function onSelectDefaultGenerator(
     },
   ];
 
-  const paymentIds = on_search_1_item[0]?.payment_ids ?? [];
+  const paymentIds = catalogItems[0]?.payment_ids ?? [];
 
   existingPayload.message.order.payments.forEach(
     (payment: any, index: number) => {

--- a/src/config/mock-config/TRV13/2.0.0/on_select/on_select_3/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/on_select/on_select_3/generator.ts
@@ -9,90 +9,85 @@ export async function onSelectDefaultGenerator(
     sessionData?.select_provider_id ?? "P1";
 
   const selectItems = sessionData?.select_items[0] ?? [];
-  // const on_search_1_item = sessionData?.on_search_1_items[0] ?? [];
+  const catalogItems = sessionData?.on_search_3_items?.[0] ?? sessionData?.on_search_1_items?.[0] ?? [];
+
+  // Find selected item in catalog to get actual prices
+  const selectedItemId = selectItems[0]?.id;
+  const catalogItem = catalogItems.find((item: any) => item.id === selectedItemId) ?? catalogItems[0];
+  
+  // Get item price from catalog
+  const itemPrice = Number(catalogItem?.price?.value ?? "2000.00");
+  const quantity = selectItems[0]?.quantity?.selected?.count ?? 1;
+  
+  // Get selected addon and its price from catalog
+  const selectedAddonId = selectItems[0]?.add_ons?.[0]?.id;
+  const catalogAddon = catalogItem?.add_ons?.find((a: any) => a.id === selectedAddonId);
+  const addonPrice = Number(catalogAddon?.price?.value ?? "500.00");
+  
+  // Calculate totals
+  const baseItemTotal = itemPrice * quantity;
+  const totalWithAddons = baseItemTotal + addonPrice;
+  const serviceTax = Math.round(totalWithAddons * 0.09);
+  const gst = Math.round(totalWithAddons * 0.12);
+  const totalPrice = totalWithAddons + serviceTax + gst;
 
   existingPayload.message.order.items = selectItems.map((item: any) => ({
     id: item.id,
     add_ons: item.add_ons,
-    // payment_ids: [on_search_1_item[0]?.payment_ids[0]],
+    payment_ids: [catalogItems[0]?.payment_ids?.[0]],
   }));
 
   existingPayload.message.order.quote = {
     price: {
       currency: "INR",
-      value: "3025.00",
+      value: totalPrice.toFixed(2),
     },
     breakup: [
       {
         item: {
-          id: selectItems[0]?.id ?? "Accommodation-1",
+          id: selectedItemId ?? "Accommodation-1",
           quantity: selectItems[0]?.quantity ?? {
             selected: {
-              count: 2,
+              count: 1,
             },
           },
           price: {
             currency: "INR",
-            value: "2000.00",
+            value: itemPrice.toFixed(2),
           },
           add_ons: [
             {
-              id: selectItems[0]?.add_ons[0]?.id ?? "full-board",
+              id: selectedAddonId ?? "full-board",
               price: {
                 currency: "INR",
-                value: "500.00",
+                value: addonPrice.toFixed(2),
               },
             },
           ],
         },
-        title:
-          "Deluxe Room accommodation with all meals included (breakfast, lunch, and dinner)",
+        title: catalogItem?.descriptor?.name ?? "Deluxe Room accommodation with all meals included",
         price: {
           currency: "INR",
-          value: "300.00",
+          value: totalWithAddons.toFixed(2),
         },
       },
       {
         title: "Service Tax @ 9%",
         price: {
           currency: "INR",
-          value: "225",
+          value: serviceTax.toString(),
         },
       },
       {
         title: "GST @ 12%",
         price: {
           currency: "INR",
-          value: "400",
+          value: gst.toString(),
         },
       },
     ],
     ttl: "P1D",
   };
-
-  let totalPrice = 0;
-
-  existingPayload.message.order.quote.breakup.forEach((breakup: any) => {
-    if (breakup.item) {
-      let itemPrice =
-        Number(breakup.item.price.value) *
-        Number(breakup.item.quantity?.selected?.count ?? 1);
-
-      if (breakup.item.add_ons?.length) {
-        itemPrice += breakup.item.add_ons.reduce(
-          (sum: number, addon: any) => sum + Number(addon.price.value),
-          0
-        );
-      }
-
-      breakup.price.value = itemPrice.toString();
-      totalPrice += itemPrice;
-    } else {
-      totalPrice += Number(breakup.price.value);
-    }
-  });
-
-  existingPayload.message.order.quote.price.value = totalPrice.toString();
 
   existingPayload.message.order.payments = [
     {
@@ -174,15 +169,15 @@ export async function onSelectDefaultGenerator(
     },
   ];
 
-  // const paymentIds = on_search_1_item[0]?.payment_ids ?? [];
+  const paymentIds = catalogItems[0]?.payment_ids ?? [];
 
-  // existingPayload.message.order.payments.forEach(
-  //   (payment: any, index: number) => {
-  //     if (index < paymentIds.length) {
-  //       payment.id = paymentIds[index];
-  //     }
-  //   }
-  // );
+  existingPayload.message.order.payments.forEach(
+    (payment: any, index: number) => {
+      if (index < paymentIds.length) {
+        payment.id = paymentIds[index];
+      }
+    }
+  );
 
   return existingPayload;
 }

--- a/src/config/mock-config/TRV13/2.0.0/on_select/on_select_4/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/on_select/on_select_4/generator.ts
@@ -9,90 +9,85 @@ export async function onSelectDefaultGenerator(
     sessionData?.select_provider_id ?? "P1";
 
   const selectItems = sessionData?.select_items[0] ?? [];
-  const on_search_1_item = sessionData?.on_search_4_items[0] ?? [];
+  const catalogItems = sessionData?.on_search_4_items?.[0] ?? sessionData?.on_search_1_items?.[0] ?? [];
+
+  // Find selected item in catalog to get actual prices
+  const selectedItemId = selectItems[0]?.id;
+  const catalogItem = catalogItems.find((item: any) => item.id === selectedItemId) ?? catalogItems[0];
+  
+  // Get item price from catalog
+  const itemPrice = Number(catalogItem?.price?.value ?? "2000.00");
+  const quantity = selectItems[0]?.quantity?.selected?.count ?? 1;
+  
+  // Get selected addon and its price from catalog
+  const selectedAddonId = selectItems[0]?.add_ons?.[0]?.id;
+  const catalogAddon = catalogItem?.add_ons?.find((a: any) => a.id === selectedAddonId);
+  const addonPrice = Number(catalogAddon?.price?.value ?? "500.00");
+  
+  // Calculate totals
+  const baseItemTotal = itemPrice * quantity;
+  const totalWithAddons = baseItemTotal + addonPrice;
+  const serviceTax = Math.round(totalWithAddons * 0.09);
+  const gst = Math.round(totalWithAddons * 0.12);
+  const totalPrice = totalWithAddons + serviceTax + gst;
 
   existingPayload.message.order.items = selectItems.map((item: any) => ({
     id: item.id,
     add_ons: item.add_ons,
-    payment_ids: [on_search_1_item[0]?.payment_ids[0]],
+    payment_ids: [catalogItems[0]?.payment_ids?.[0]],
   }));
 
   existingPayload.message.order.quote = {
     price: {
       currency: "INR",
-      value: "3025.00",
+      value: totalPrice.toFixed(2),
     },
     breakup: [
       {
         item: {
-          id: selectItems[0]?.id ?? "Accommodation-1",
+          id: selectedItemId ?? "Accommodation-1",
           quantity: selectItems[0]?.quantity ?? {
             selected: {
-              count: 2,
+              count: 1,
             },
           },
           price: {
             currency: "INR",
-            value: "2000.00",
+            value: itemPrice.toFixed(2),
           },
           add_ons: [
             {
-              id: selectItems[0]?.add_ons[0]?.id ?? "full-board",
+              id: selectedAddonId ?? "full-board",
               price: {
                 currency: "INR",
-                value: "500.00",
+                value: addonPrice.toFixed(2),
               },
             },
           ],
         },
-        title:
-          "Deluxe Room accommodation with all meals included (breakfast, lunch, and dinner)",
+        title: catalogItem?.descriptor?.name ?? "Deluxe Room accommodation with all meals included",
         price: {
           currency: "INR",
-          value: "300.00",
+          value: totalWithAddons.toFixed(2),
         },
       },
       {
         title: "Service Tax @ 9%",
         price: {
           currency: "INR",
-          value: "225",
+          value: serviceTax.toString(),
         },
       },
       {
         title: "GST @ 12%",
         price: {
           currency: "INR",
-          value: "400",
+          value: gst.toString(),
         },
       },
     ],
     ttl: "P1D",
   };
-
-  let totalPrice = 0;
-
-  existingPayload.message.order.quote.breakup.forEach((breakup: any) => {
-    if (breakup.item) {
-      let itemPrice =
-        Number(breakup.item.price.value) *
-        Number(breakup.item.quantity?.selected?.count ?? 1);
-
-      if (breakup.item.add_ons?.length) {
-        itemPrice += breakup.item.add_ons.reduce(
-          (sum: number, addon: any) => sum + Number(addon.price.value),
-          0
-        );
-      }
-
-      breakup.price.value = itemPrice.toString();
-      totalPrice += itemPrice;
-    } else {
-      totalPrice += Number(breakup.price.value);
-    }
-  });
-
-  existingPayload.message.order.quote.price.value = totalPrice.toString();
 
   existingPayload.message.order.payments = [
     {
@@ -174,7 +169,7 @@ export async function onSelectDefaultGenerator(
     },
   ];
 
-  const paymentIds = on_search_1_item[0]?.payment_ids ?? [];
+  const paymentIds = catalogItems[0]?.payment_ids ?? [];
 
   existingPayload.message.order.payments.forEach(
     (payment: any, index: number) => {

--- a/src/config/mock-config/TRV13/2.0.0/select/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/select/generator.ts
@@ -13,20 +13,23 @@ export async function selectDefaultGenerator(
         end: "2023-12-27T00:00:00.000Z",
       },
     };
-  // ...existing code...
-  existingPayload.message.order.items = [
-    {
-      id: items[0]?.id ?? "P1",
-      location_ids: [...(items[0]?.location_ids ?? [])],
-      quantity: {
-        selected: {
-          count: 1,
+
+  // If no items in payload, use defaults from session
+  if (!existingPayload.message.order.items || existingPayload.message.order.items.length === 0) {
+    existingPayload.message.order.items = [
+      {
+        id: items[0]?.id ?? "P1",
+        location_ids: [...(items[0]?.location_ids ?? [])],
+        quantity: {
+          selected: {
+            count: 1,
+          },
         },
+        add_ons: [{ id: items[0]?.add_ons?.[1]?.id ?? "full-board" }],
       },
-      add_ons: [{ id: items[0]?.add_ons?.[1]?.id ?? "full-board" }],
-    },
-  ];
-  // ...existing code...
+    ];
+  }
+
   return existingPayload;
 }
 

--- a/src/config/mock-config/TRV13/2.0.0/select/select_1/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/select/select_1/generator.ts
@@ -13,20 +13,23 @@ export async function selectDefaultGenerator(
         end: "2023-12-27T00:00:00.000Z",
       },
     };
-  // ...existing code...
-  existingPayload.message.order.items = [
-    {
-      id: items[0]?.id ?? "P1",
-      location_ids: [...(items[0]?.location_ids ?? [])],
-      quantity: {
-        selected: {
-          count: 1,
+
+  // If no items in payload, use defaults from session
+  if (!existingPayload.message.order.items || existingPayload.message.order.items.length === 0) {
+    existingPayload.message.order.items = [
+      {
+        id: items[0]?.id ?? "P1",
+        location_ids: [...(items[0]?.location_ids ?? [])],
+        quantity: {
+          selected: {
+            count: 1,
+          },
         },
+        add_ons: [{ id: items[0]?.add_ons?.[1]?.id ?? "full-board" }],
       },
-      add_ons: [{ id: items[0]?.add_ons?.[1]?.id ?? "full-board" }],
-    },
-  ];
-  // ...existing code...
+    ];
+  }
+
   return existingPayload;
 }
 

--- a/src/config/mock-config/TRV13/2.0.0/select/select_3/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/select/select_3/generator.ts
@@ -2,123 +2,33 @@ export async function selectDefaultGenerator(
   existingPayload: any,
   sessionData: any
 ) {
-  const items = sessionData?.on_search_3_items[0] ?? [];
+  const items = sessionData?.on_search_3_items?.[0] ?? sessionData?.on_search_1_items?.[0] ?? [];
   existingPayload.message.order.provider.id =
-    sessionData?.on_search_3_provider_id ?? "P1";
+    sessionData?.on_search_3_provider_id ?? sessionData?.on_search_1_provider_id ?? "P1";
   existingPayload.message.order.provider.time =
-    sessionData?.search_3_provider_time ?? {
+    sessionData?.search_3_provider_time ?? sessionData?.search_1_provider_time ?? {
       label: "AVAILABLE",
       range: {
         start: "2023-12-25T00:00:00.000Z",
         end: "2023-12-27T00:00:00.000Z",
       },
     };
-  // ...existing code...
-  existingPayload.message.order.items = [
-    {
-      id: items[0]?.id ?? "P1",
-      location_ids: [...(items[0]?.location_ids ?? [])],
-      quantity: {
-        selected: {
-          count: 1,
+
+  // If no items in payload, use defaults from session
+  if (!existingPayload.message.order.items || existingPayload.message.order.items.length === 0) {
+    existingPayload.message.order.items = [
+      {
+        id: items[0]?.id ?? "P1",
+        location_ids: [...(items[0]?.location_ids ?? [])],
+        quantity: {
+          selected: {
+            count: 1,
+          },
         },
+        add_ons: [{ id: items[0]?.add_ons?.[1]?.id ?? "full-board" }],
       },
-      add_ons: [{ id: items[0]?.add_ons?.[1]?.id ?? "full-board" }],
-    },
-  ];
-  // ...existing code...
+    ];
+  }
+
   return existingPayload;
 }
-
-// /**
-//  * Super Simplified Select Generator for TRV14
-//  *
-//  * Logic:
-//  * 1. Select the 0th index item from sessionData.items
-//  * 2. Always use quantity count = 1 for both item and add-ons
-//  * 3. Include add-ons if they exist on the selected item
-//  * 4. Use 0th index fulfillment from item's fulfillment_ids
-//  * 5. Use provider_id from session data
-//  * 6. Update fulfillment timestamps to match context timestamp
-//  */
-
-// /**
-//  * Creates item payload with quantity and add-ons
-//  * @param selectedItem - The item object from sessionData.items
-//  * @returns Formatted item payload for the select request
-//  */
-// function createItemPayload(selectedItem: any): any {
-//   const itemPayload: any = {
-//     id: selectedItem.id,
-//     quantity: {
-//       selected: {
-//         count: 1
-//       }
-//     }
-//   };
-
-//   // Add parent_item_id if it exists
-//   if (selectedItem.parent_item_id) {
-//     itemPayload.parent_item_id = selectedItem.parent_item_id;
-//   }
-
-//   // Add add-ons if they exist
-//   if (selectedItem.add_ons && Array.isArray(selectedItem.add_ons) && selectedItem.add_ons.length > 0) {
-//     itemPayload.add_ons = selectedItem.add_ons.map((addOn: any) => ({
-//       id: addOn.id,
-//       quantity: {
-//         selected: {
-//           count: 1
-//         }
-//       }
-//     }));
-//   }
-
-//   return itemPayload;
-// }
-
-// export async function selectDefaultGenerator(existingPayload: any, sessionData: any) {
-//   // Note: Validation is handled in meetRequirements method of the class
-
-//   // Select the first item (index 0)
-//   let selectedItem: any;
-//   if(sessionData.items.length > 0){
-//      selectedItem = sessionData.items[1];
-//   }
-//   else{
-//      selectedItem = sessionData.items[0];
-//   }
-
-//   // Create item payload for the selected item only (don't include parent in select payload)
-//   const selectedItemPayload = createItemPayload(selectedItem);
-
-//   // Update the payload with only the selected item
-//   existingPayload.message.order.items = [selectedItemPayload];
-
-//   // Handle provider ID
-//   existingPayload.message.order.provider.id = sessionData.provider_id;
-
-//   // Handle fulfillments: use 0th fulfillment ID from selected item
-//   if (selectedItem.fulfillment_ids && Array.isArray(selectedItem.fulfillment_ids) && selectedItem.fulfillment_ids.length > 0) {
-//     const selectedFulfillmentId = selectedItem.fulfillment_ids[0];
-//     existingPayload.message.order.fulfillments = (existingPayload.message.order.fulfillments || []).filter((f: any) =>
-//       f.id === selectedFulfillmentId
-//     );
-//   }
-
-//   // Update fulfillment timestamps to match context timestamp
-//   if (Array.isArray(existingPayload.message.order.fulfillments) && existingPayload.context?.timestamp) {
-//     const contextTimestamp = existingPayload.context.timestamp;
-//     existingPayload.message.order.fulfillments.forEach((fulfillment: any) => {
-//       if (Array.isArray(fulfillment.stops)) {
-//         fulfillment.stops.forEach((stop: any) => {
-//           if (stop.time?.timestamp) {
-//             stop.time.timestamp = contextTimestamp;
-//           }
-//         });
-//       }
-//     });
-//   }
-
-//   return existingPayload;
-// }

--- a/src/config/mock-config/TRV13/2.0.0/select/select_4/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/select/select_4/generator.ts
@@ -2,123 +2,33 @@ export async function selectDefaultGenerator(
   existingPayload: any,
   sessionData: any
 ) {
-  const items = sessionData?.on_search_4_items[0] ?? [];
+  const items = sessionData?.on_search_4_items?.[0] ?? sessionData?.on_search_1_items?.[0] ?? [];
   existingPayload.message.order.provider.id =
-  sessionData?.on_search_4_provider_id ?? "P1";
+    sessionData?.on_search_4_provider_id ?? sessionData?.on_search_1_provider_id ?? "P1";
   existingPayload.message.order.provider.time =
-    sessionData?.search_4_provider_time ?? {
+    sessionData?.search_4_provider_time ?? sessionData?.search_1_provider_time ?? {
       label: "AVAILABLE",
       range: {
         start: "2023-12-25T00:00:00.000Z",
         end: "2023-12-27T00:00:00.000Z",
       },
     };
-  // ...existing code...
-  existingPayload.message.order.items = [
-    {
-      id: items[0]?.id ?? "P1",
-      location_ids: [...(items[0]?.location_ids ?? [])],
-      quantity: {
-        selected: {
-          count: 1,
+
+  // If no items in payload, use defaults from session
+  if (!existingPayload.message.order.items || existingPayload.message.order.items.length === 0) {
+    existingPayload.message.order.items = [
+      {
+        id: items[0]?.id ?? "P1",
+        location_ids: [...(items[0]?.location_ids ?? [])],
+        quantity: {
+          selected: {
+            count: 1,
+          },
         },
+        add_ons: [{ id: items[0]?.add_ons?.[1]?.id ?? "full-board" }],
       },
-      add_ons: [{ id: items[0]?.add_ons?.[1]?.id ?? "full-board" }],
-    },
-  ];
-  // ...existing code...
+    ];
+  }
+
   return existingPayload;
 }
-
-// /**
-//  * Super Simplified Select Generator for TRV14
-//  *
-//  * Logic:
-//  * 1. Select the 0th index item from sessionData.items
-//  * 2. Always use quantity count = 1 for both item and add-ons
-//  * 3. Include add-ons if they exist on the selected item
-//  * 4. Use 0th index fulfillment from item's fulfillment_ids
-//  * 5. Use provider_id from session data
-//  * 6. Update fulfillment timestamps to match context timestamp
-//  */
-
-// /**
-//  * Creates item payload with quantity and add-ons
-//  * @param selectedItem - The item object from sessionData.items
-//  * @returns Formatted item payload for the select request
-//  */
-// function createItemPayload(selectedItem: any): any {
-//   const itemPayload: any = {
-//     id: selectedItem.id,
-//     quantity: {
-//       selected: {
-//         count: 1
-//       }
-//     }
-//   };
-
-//   // Add parent_item_id if it exists
-//   if (selectedItem.parent_item_id) {
-//     itemPayload.parent_item_id = selectedItem.parent_item_id;
-//   }
-
-//   // Add add-ons if they exist
-//   if (selectedItem.add_ons && Array.isArray(selectedItem.add_ons) && selectedItem.add_ons.length > 0) {
-//     itemPayload.add_ons = selectedItem.add_ons.map((addOn: any) => ({
-//       id: addOn.id,
-//       quantity: {
-//         selected: {
-//           count: 1
-//         }
-//       }
-//     }));
-//   }
-
-//   return itemPayload;
-// }
-
-// export async function selectDefaultGenerator(existingPayload: any, sessionData: any) {
-//   // Note: Validation is handled in meetRequirements method of the class
-
-//   // Select the first item (index 0)
-//   let selectedItem: any;
-//   if(sessionData.items.length > 0){
-//      selectedItem = sessionData.items[1];
-//   }
-//   else{
-//      selectedItem = sessionData.items[0];
-//   }
-
-//   // Create item payload for the selected item only (don't include parent in select payload)
-//   const selectedItemPayload = createItemPayload(selectedItem);
-
-//   // Update the payload with only the selected item
-//   existingPayload.message.order.items = [selectedItemPayload];
-
-//   // Handle provider ID
-//   existingPayload.message.order.provider.id = sessionData.provider_id;
-
-//   // Handle fulfillments: use 0th fulfillment ID from selected item
-//   if (selectedItem.fulfillment_ids && Array.isArray(selectedItem.fulfillment_ids) && selectedItem.fulfillment_ids.length > 0) {
-//     const selectedFulfillmentId = selectedItem.fulfillment_ids[0];
-//     existingPayload.message.order.fulfillments = (existingPayload.message.order.fulfillments || []).filter((f: any) =>
-//       f.id === selectedFulfillmentId
-//     );
-//   }
-
-//   // Update fulfillment timestamps to match context timestamp
-//   if (Array.isArray(existingPayload.message.order.fulfillments) && existingPayload.context?.timestamp) {
-//     const contextTimestamp = existingPayload.context.timestamp;
-//     existingPayload.message.order.fulfillments.forEach((fulfillment: any) => {
-//       if (Array.isArray(fulfillment.stops)) {
-//         fulfillment.stops.forEach((stop: any) => {
-//           if (stop.time?.timestamp) {
-//             stop.time.timestamp = contextTimestamp;
-//           }
-//         });
-//       }
-//     });
-//   }
-
-//   return existingPayload;
-// }


### PR DESCRIPTION
### Changes:

- Added transaction_id generation for PRE-ORDER PAID payments in confirm generators
- Updated on_select generators to calculate quote dynamically from breakup
- Updated select generators to use session data for items
- Fixes Issue 342: hardcoded values in payment and quote