### PR TITLE
fix(TRV13): Calculate payment amounts dynamically from quote total

### DIFF
--- a/src/config/mock-config/TRV13/2.0.0/on_select/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/on_select/generator.ts
@@ -92,10 +92,18 @@ export async function onSelectDefaultGenerator(
 
 
 
+  // Calculate payment amounts from quote total
+  const advanceDepositAmount = (totalPrice * 0.5).toFixed(2); // 50% advance
+  const finalPaymentAmount = (totalPrice * 0.5).toFixed(2); // 50% remaining
+
   existingPayload.message.order.payments = [
     {
       id: "pymnt-1",
       type: "PRE-ORDER",
+      params: {
+        currency: "INR",
+        amount: totalPrice.toFixed(2),
+      },
       tags: [
         {
           descriptor: {
@@ -107,6 +115,10 @@ export async function onSelectDefaultGenerator(
     {
       id: "pymnt-2",
       type: "ON-FULFILLMENT",
+      params: {
+        currency: "INR",
+        amount: totalPrice.toFixed(2),
+      },
       tags: [
         {
           descriptor: {
@@ -118,6 +130,10 @@ export async function onSelectDefaultGenerator(
     {
       id: "pymnt-3",
       type: "PART-PAYMENT",
+      params: {
+        currency: "INR",
+        amount: totalPrice.toFixed(2),
+      },
       tags: [
         {
           descriptor: {
@@ -152,7 +168,7 @@ export async function onSelectDefaultGenerator(
       ],
       params: {
         currency: "INR",
-        amount: "2000.00",
+        amount: advanceDepositAmount,
       },
     },
     {
@@ -166,8 +182,8 @@ export async function onSelectDefaultGenerator(
         },
       ],
       params: {
-        amount: "1025.00",
         currency: "INR",
+        amount: finalPaymentAmount,
       },
     },
   ];


### PR DESCRIPTION
- PRE-ORDER, ON-FULFILLMENT, PART-PAYMENT payments now include params.amount from quote
- ADV-DEPOSIT set to 50% of total price
- FINAL-PAYMENT set to 50% of total price
- Fixes GitHub Issue 342: Payment parameters amount is incorrect