### PR TITLE
fix(TRV13): Replace hardcoded payment amounts with dynamic calculations

### DIFF
--- a/src/config/mock-config/TRV13/2.0.0/on_select/on_select_1/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/on_select/on_select_1/generator.ts
@@ -92,10 +92,18 @@ export async function onSelectDefaultGenerator(
 
 
 
+  // Calculate payment amounts from quote total
+  const advanceDepositAmount = (totalPrice * 0.5).toFixed(2); // 50% advance
+  const finalPaymentAmount = (totalPrice * 0.5).toFixed(2); // 50% remaining
+
   existingPayload.message.order.payments = [
     {
       id: "pymnt-1",
       type: "PRE-ORDER",
+      params: {
+        currency: "INR",
+        amount: totalPrice.toFixed(2),
+      },
       tags: [
         {
           descriptor: {
@@ -107,6 +115,10 @@ export async function onSelectDefaultGenerator(
     {
       id: "pymnt-2",
       type: "ON-FULFILLMENT",
+      params: {
+        currency: "INR",
+        amount: totalPrice.toFixed(2),
+      },
       tags: [
         {
           descriptor: {
@@ -118,6 +130,10 @@ export async function onSelectDefaultGenerator(
     {
       id: "pymnt-3",
       type: "PART-PAYMENT",
+      params: {
+        currency: "INR",
+        amount: totalPrice.toFixed(2),
+      },
       tags: [
         {
           descriptor: {
@@ -152,7 +168,7 @@ export async function onSelectDefaultGenerator(
       ],
       params: {
         currency: "INR",
-        amount: "2000.00",
+        amount: advanceDepositAmount,
       },
     },
     {
@@ -166,8 +182,8 @@ export async function onSelectDefaultGenerator(
         },
       ],
       params: {
-        amount: "1025.00",
         currency: "INR",
+        amount: finalPaymentAmount,
       },
     },
   ];

--- a/src/config/mock-config/TRV13/2.0.0/on_select/on_select_2/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/on_select/on_select_2/generator.ts
@@ -94,10 +94,18 @@ export async function onSelectDefaultGenerator(
 
   existingPayload.message.order.quote.price.value = totalPrice.toString();
 
+  // Calculate payment amounts from quote total
+  const advanceDepositAmount = (totalPrice * 0.5).toFixed(2); // 50% advance
+  const finalPaymentAmount = (totalPrice * 0.5).toFixed(2); // 50% remaining
+
   existingPayload.message.order.payments = [
     {
       id: "pymnt-1",
       type: "PRE-ORDER",
+      params: {
+        currency: "INR",
+        amount: totalPrice.toFixed(2),
+      },
       tags: [
         {
           descriptor: {
@@ -109,6 +117,10 @@ export async function onSelectDefaultGenerator(
     {
       id: "pymnt-2",
       type: "ON-FULFILLMENT",
+      params: {
+        currency: "INR",
+        amount: totalPrice.toFixed(2),
+      },
       tags: [
         {
           descriptor: {
@@ -120,6 +132,10 @@ export async function onSelectDefaultGenerator(
     {
       id: "pymnt-3",
       type: "PART-PAYMENT",
+      params: {
+        currency: "INR",
+        amount: totalPrice.toFixed(2),
+      },
       tags: [
         {
           descriptor: {
@@ -154,7 +170,7 @@ export async function onSelectDefaultGenerator(
       ],
       params: {
         currency: "INR",
-        amount: "2000.00",
+        amount: advanceDepositAmount,
       },
     },
     {
@@ -168,8 +184,8 @@ export async function onSelectDefaultGenerator(
         },
       ],
       params: {
-        amount: "1025.00",
         currency: "INR",
+        amount: finalPaymentAmount,
       },
     },
   ];

--- a/src/config/mock-config/TRV13/2.0.0/on_select/on_select_3/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/on_select/on_select_3/generator.ts
@@ -89,10 +89,18 @@ export async function onSelectDefaultGenerator(
     ttl: "P1D",
   };
 
+  // Calculate payment amounts from quote total
+  const advanceDepositAmount = (totalPrice * 0.5).toFixed(2); // 50% advance
+  const finalPaymentAmount = (totalPrice * 0.5).toFixed(2); // 50% remaining
+
   existingPayload.message.order.payments = [
     {
       id: "pymnt-1",
       type: "PRE-ORDER",
+      params: {
+        currency: "INR",
+        amount: totalPrice.toFixed(2),
+      },
       tags: [
         {
           descriptor: {
@@ -104,6 +112,10 @@ export async function onSelectDefaultGenerator(
     {
       id: "pymnt-2",
       type: "ON-FULFILLMENT",
+      params: {
+        currency: "INR",
+        amount: totalPrice.toFixed(2),
+      },
       tags: [
         {
           descriptor: {
@@ -115,6 +127,10 @@ export async function onSelectDefaultGenerator(
     {
       id: "pymnt-3",
       type: "PART-PAYMENT",
+      params: {
+        currency: "INR",
+        amount: totalPrice.toFixed(2),
+      },
       tags: [
         {
           descriptor: {
@@ -149,7 +165,7 @@ export async function onSelectDefaultGenerator(
       ],
       params: {
         currency: "INR",
-        amount: "2000.00",
+        amount: advanceDepositAmount,
       },
     },
     {
@@ -163,8 +179,8 @@ export async function onSelectDefaultGenerator(
         },
       ],
       params: {
-        amount: "1025.00",
         currency: "INR",
+        amount: finalPaymentAmount,
       },
     },
   ];

--- a/src/config/mock-config/TRV13/2.0.0/on_select/on_select_4/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/on_select/on_select_4/generator.ts
@@ -89,10 +89,18 @@ export async function onSelectDefaultGenerator(
     ttl: "P1D",
   };
 
+  // Calculate payment amounts from quote total
+  const advanceDepositAmount = (totalPrice * 0.5).toFixed(2); // 50% advance
+  const finalPaymentAmount = (totalPrice * 0.5).toFixed(2); // 50% remaining
+
   existingPayload.message.order.payments = [
     {
       id: "pymnt-1",
       type: "PRE-ORDER",
+      params: {
+        currency: "INR",
+        amount: totalPrice.toFixed(2),
+      },
       tags: [
         {
           descriptor: {
@@ -104,6 +112,10 @@ export async function onSelectDefaultGenerator(
     {
       id: "pymnt-2",
       type: "ON-FULFILLMENT",
+      params: {
+        currency: "INR",
+        amount: totalPrice.toFixed(2),
+      },
       tags: [
         {
           descriptor: {
@@ -115,6 +127,10 @@ export async function onSelectDefaultGenerator(
     {
       id: "pymnt-3",
       type: "PART-PAYMENT",
+      params: {
+        currency: "INR",
+        amount: totalPrice.toFixed(2),
+      },
       tags: [
         {
           descriptor: {
@@ -149,7 +165,7 @@ export async function onSelectDefaultGenerator(
       ],
       params: {
         currency: "INR",
-        amount: "2000.00",
+        amount: advanceDepositAmount,
       },
     },
     {
@@ -163,8 +179,8 @@ export async function onSelectDefaultGenerator(
         },
       ],
       params: {
-        amount: "1025.00",
         currency: "INR",
+        amount: finalPaymentAmount,
       },
     },
   ];


### PR DESCRIPTION
- on_select_1: Use totalPrice for payments, 50% advance/50% final for part-payment
- on_select_2: Use totalPrice for payments, 50% advance/50% final for part-payment
- on_select_3: Use totalPrice for payments, 50% advance/50% final for part-payment
- on_select_4: Use totalPrice for payments, 50% advance/50% final for part-payment

Removed hardcoded 1025.00 and 2000.00 amounts