### PR TITLE
fix(TRV13): Correct GST calculation and DELAY_INTEREST value

### DIFF
--- a/src/config/mock-config/TRV13/2.0.1/on_init/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.1/on_init/generator.ts
@@ -52,7 +52,7 @@ export async function onInitDefaultGenerator(
           descriptor: {
             code: "DELAY_INTEREST",
           },
-          value: "New Delhi",
+          value: "5",
         },
         {
           descriptor: {

--- a/src/config/mock-config/TRV13/2.0.1/on_select/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.1/on_select/generator.ts
@@ -63,7 +63,7 @@ export async function onSelectDefaultGenerator(
         title: "GST @ 12%",
         price: {
           currency: "INR",
-          value: "400",
+          value: "300",
         },
       },
     ],


### PR DESCRIPTION
- Fix GST @ 12% from 400 to 300 (correct 12% of 2500 base)
- Fix DELAY_INTEREST from 'New Delhi' to '5' (copy-paste error)