### PR TITLE
fix(TRV13): update on_select generator to use on_search_1_items

### DIFF
--- a/src/config/mock-config/TRV13/2.0.1/on_select/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.1/on_select/generator.ts
@@ -9,7 +9,8 @@ export async function onSelectDefaultGenerator(
     sessionData?.select_provider_id ?? "P1";
 
   const selectItems = sessionData?.select_items[0] ?? [];
-  const on_search_5_item = sessionData?.on_search_5_items[0] ?? [];
+  // Use on_search_1_items (from on_search_6) with fallback to on_search_5_items
+  const on_search_5_item = sessionData?.on_search_1_items?.[0] ?? sessionData?.on_search_5_items?.[0] ?? [];
 
   existingPayload.message.order.items = selectItems.map((item: any) => ({
     id: item.id,


### PR DESCRIPTION
- Uses on_search_1_items from on_search_6 session data
- Falls back to on_search_5_items for backward compatibility
- Fixes flow getting stuck on on_select after search_6 migration