### PR TITLE
fix(TRV13): update init generator to use search_6_tags

### DIFF
--- a/src/config/mock-config/TRV13/2.0.1/init/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.1/init/generator.ts
@@ -5,7 +5,8 @@ export async function initDefaultGenerator(
   existingPayload.message.order.provider.id =
     sessionData?.select_provider_id ?? "P1";
   existingPayload.message.order.items = sessionData?.select_items[0] ?? [];
-  existingPayload.message.order.tags = sessionData?.search_5_tags[0] ?? [];
+  // Use search_6_tags (from search_6) with fallback to search_5_tags
+  existingPayload.message.order.tags = sessionData?.search_6_tags?.[0] ?? sessionData?.search_5_tags?.[0] ?? [];
   let payments = sessionData?.select_payments[0].filter(
     (_: any, index: number) => index >= 2
   );


### PR DESCRIPTION
- Uses search_6_tags from search_6 session data
- Falls back to search_5_tags for backward compatibility
- Fixes flow getting stuck on on_init after search_6 migration