### PR TITLE
fix(TRV13): add optional chaining to prevent selectItems.map crash

### DIFF
--- a/src/config/mock-config/TRV13/2.0.1/on_select/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.1/on_select/generator.ts
@@ -8,7 +8,7 @@ export async function onSelectDefaultGenerator(
   existingPayload.message.order.provider.id =
     sessionData?.select_provider_id ?? "P1";
 
-  const selectItems = sessionData?.select_items[0] ?? [];
+  const selectItems = sessionData?.select_items?.[0] ?? [];
   // Use on_search_1_items (from on_search_6) with fallback to on_search_5_items
   const on_search_5_item = sessionData?.on_search_1_items?.[0] ?? sessionData?.on_search_5_items?.[0] ?? [];
 


### PR DESCRIPTION
- Fixed: sessionData?.select_items[0] → sessionData?.select_items?.[0]
- Prevents TypeError when select_items is undefined