### PR TITLE
fix(TRV11-METRO): preserve fulfillment_ids in on_select generator

### DIFF
--- a/src/config/mock-config/TRV11/METRO/2.0.0/on_select/generator.ts
+++ b/src/config/mock-config/TRV11/METRO/2.0.0/on_select/generator.ts
@@ -65,9 +65,14 @@ function createAndAppendFulfillments(items: any[], fulfillments: any[]): void {
 				}
 			}
 		});
-		item.fulfillment_ids.shift()
+		// Only remove original if new fulfillments were added (preserve at least one)
+		if (item.fulfillment_ids.length > 1) {
+			item.fulfillment_ids.shift();
+		}
 	});
-	fulfillments.shift()
+	if (fulfillments.length > 1) {
+		fulfillments.shift();
+	}
 }
 
 


### PR DESCRIPTION
Fix empty fulfillment_ids validation error by only calling shift() when array has more than 1 element. This ensures at least one fulfillment_id is always preserved for each item.