### PR TITLE
fix(TRV11-METRO): change descriptor.code from Pass to PASS

### DIFF
--- a/src/config/mock-config/TRV11/METRO/2.0.0/on_confirm/on_confirm_pass/default.yaml
+++ b/src/config/mock-config/TRV11/METRO/2.0.0/on_confirm/on_confirm_pass/default.yaml
@@ -8,7 +8,7 @@ message:
           - C2
         descriptor:
           name: Journey Pass
-          code: Pass
+          code: PASS
         price:
           currency: INR
           value: '1500'

--- a/src/config/mock-config/TRV11/METRO/2.0.0/on_init/on_init_pass/default.yaml
+++ b/src/config/mock-config/TRV11/METRO/2.0.0/on_init/on_init_pass/default.yaml
@@ -6,7 +6,7 @@ message:
           - C2
         descriptor:
           name: Journey Pass
-          code: Pass
+          code: PASS
         price:
           currency: INR
           value: '1500'

--- a/src/config/mock-config/TRV11/METRO/2.0.0/on_search/on_search2/default.yaml
+++ b/src/config/mock-config/TRV11/METRO/2.0.0/on_search/on_search2/default.yaml
@@ -67,7 +67,7 @@ message:
               - C2
             descriptor:
               name: Journey Pass
-              code: Pass
+              code: PASS
             price:
               currency: INR
               value: '1500'

--- a/src/config/mock-config/TRV11/METRO/2.0.0/on_select/on_select_pass/default.yaml
+++ b/src/config/mock-config/TRV11/METRO/2.0.0/on_select/on_select_pass/default.yaml
@@ -6,7 +6,7 @@ message:
           - C2
         descriptor:
           name: Journey Pass
-          code: Pass
+          code: PASS
         price:
           currency: INR
           value: '1500'

--- a/src/config/mock-config/TRV11/METRO/2.0.0/on_status/on_status_pass/default.yaml
+++ b/src/config/mock-config/TRV11/METRO/2.0.0/on_status/on_status_pass/default.yaml
@@ -6,7 +6,7 @@ message:
       - id: I3
         descriptor:
           name: Journey Pass
-          code: Pass
+          code: PASS
         category_ids:
           - C2
         price:


### PR DESCRIPTION
Validation requires code to be in [SJT, SFSJT, RJT, PASS] (uppercase)