### PR TITLE
fix(TRV11-METRO): Flow 1 SJT Journey Completion fixes

### DIFF
--- a/src/config/mock-config/TRV11/METRO/2.0.0/on_confirm/on_confirm/generator.ts
+++ b/src/config/mock-config/TRV11/METRO/2.0.0/on_confirm/on_confirm/generator.ts
@@ -14,7 +14,11 @@ function updateOrderTimestamps(payload: any) {
   }
 
 function updateFulfillmentsWithParentInfo(fulfillments: any[]): void {
-	const validTo = "2024-07-23T23:59:59.999Z";
+	// Calculate valid_to as 2 days from now (P2D validity per contract)
+	const validToDate = new Date();
+	validToDate.setDate(validToDate.getDate() + 2);
+	validToDate.setHours(23, 59, 59, 999);
+	const validTo = validToDate.toISOString();
 
 	fulfillments.forEach((fulfillment) => {
 		// Generate a random QR token

--- a/src/config/mock-config/TRV11/METRO/2.0.0/on_status/on_status_complete/generator.ts
+++ b/src/config/mock-config/TRV11/METRO/2.0.0/on_status/on_status_complete/generator.ts
@@ -11,7 +11,28 @@ export async function onStatusCompleteGenerator(existingPayload: any,sessionData
 	}
 
 	if (sessionData.fulfillments.length > 0) {
-	existingPayload.message.order.fulfillments = sessionData.fulfillments;
+	// Deep clone to avoid mutating sessionData
+	const fulfillments = JSON.parse(JSON.stringify(sessionData.fulfillments));
+	
+	// Add state and update authorization for journey completion
+	fulfillments.forEach((fulfillment: any) => {
+		// Enhancement 1: Add fulfillment state for journey completed
+		fulfillment.state = {
+			descriptor: {
+				code: "COMPLETE"
+			}
+		};
+		
+		// Enhancement 2: Update authorization status to CLAIMED in START stop
+		if (fulfillment.stops && fulfillment.stops.length > 0) {
+			const startStop = fulfillment.stops.find((s: any) => s.type === "START");
+			if (startStop && startStop.authorization) {
+				startStop.authorization.status = "CLAIMED";
+			}
+		}
+	});
+	
+	existingPayload.message.order.fulfillments = fulfillments;
 	}
 	if (sessionData.order_id) {
 	existingPayload.message.order.id = sessionData.order_id;
@@ -19,7 +40,7 @@ export async function onStatusCompleteGenerator(existingPayload: any,sessionData
 	if(sessionData.quote != null){
 	existingPayload.message.order.quote = sessionData.quote
 	}
-    existingPayload.message.order.status = "COMPLETE"
+    existingPayload.message.order.status = "COMPLETED"
 	const now = new Date().toISOString();
     existingPayload.message.order.created_at = sessionData.created_at
     existingPayload.message.order.updated_at = now


### PR DESCRIPTION
- on_confirm: Calculate valid_to dynamically (now + 2 days)
- on_status_complete: Change order.status to COMPLETED
- on_status_complete: Add fulfillment.state.descriptor.code = COMPLETE
- on_status_complete: Set authorization.status = CLAIMED