### PR TITLE
feat(TRV11-METRO): Flow 2 Monthly Pass implementation

### DIFF
--- a/src/config/mock-config/TRV11/METRO/2.0.0/on_confirm/on_confirm/generator.ts
+++ b/src/config/mock-config/TRV11/METRO/2.0.0/on_confirm/on_confirm/generator.ts
@@ -13,10 +13,16 @@ function updateOrderTimestamps(payload: any) {
 	return payload;
   }
 
-function updateFulfillmentsWithParentInfo(fulfillments: any[]): void {
-	// Calculate valid_to as 2 days from now (P2D validity per contract)
+function updateFulfillmentsWithParentInfo(fulfillments: any[], isPassFlow: boolean = false): void {
+	// Calculate valid_to based on flow type
 	const validToDate = new Date();
-	validToDate.setDate(validToDate.getDate() + 2);
+	if (isPassFlow) {
+		// P30D - Monthly Pass validity
+		validToDate.setDate(validToDate.getDate() + 30);
+	} else {
+		// P2D - SJT/RJT validity
+		validToDate.setDate(validToDate.getDate() + 2);
+	}
 	validToDate.setHours(23, 59, 59, 999);
 	const validTo = validToDate.toISOString();
 
@@ -84,7 +90,10 @@ export async function onConfirmGenerator(
 	if (!Array.isArray(sessionData.updated_payments)) {
 		sessionData.updated_payments = [sessionData.updated_payments];
 	}
-	updateFulfillmentsWithParentInfo(sessionData.fulfillments);
+	
+	// Detect Monthly Pass flow for P30D validity
+	const isPassFlow = sessionData.flowId === "ORDER_TO_CONFIRM_MONTHLY_PASS";
+	updateFulfillmentsWithParentInfo(sessionData.fulfillments, isPassFlow);
 	existingPayload.message.order.payments = updated_payments;
 	
 	  // Check if items is a non-empty array

--- a/src/config/mock-config/TRV11/METRO/2.0.0/on_search/on_search2/default.yaml
+++ b/src/config/mock-config/TRV11/METRO/2.0.0/on_search/on_search2/default.yaml
@@ -62,6 +62,25 @@ message:
             time:
               label: Validity
               duration: P2D
+          - id: I3
+            category_ids:
+              - C2
+            descriptor:
+              name: Journey Pass
+              code: PASS
+            price:
+              currency: INR
+              value: '500'
+            quantity:
+              maximum:
+                count: 1
+              minimum:
+                count: 1
+            fulfillment_ids:
+              - F2
+            time:
+              label: Validity
+              duration: P30D
         fulfillments:
           - id: F1
             type: TRIP

--- a/src/config/mock-config/TRV11/METRO/2.0.0/on_select/generator.ts
+++ b/src/config/mock-config/TRV11/METRO/2.0.0/on_select/generator.ts
@@ -104,6 +104,32 @@ export async function onSelectGenerator(
     existingPayload: any,
     sessionData: SessionData
 ) {
+	// Detect Monthly Pass flow
+	const isPassFlow = sessionData.flowId === "ORDER_TO_CONFIRM_MONTHLY_PASS";
+	
+	if (isPassFlow) {
+		// For Pass flow, use I3 with F2 fulfillment
+		const passItem = sessionData.items.find((item: any) => item.id === "I3");
+		if (passItem) {
+			const passItemWithQuantity = {
+				...passItem,
+				quantity: { selected: { count: 1 } }
+			};
+			
+			// Get F2 fulfillment for Pass
+			const passFulfillment = sessionData.fulfillments.find((f: any) => f.id === "F2");
+			const fulfillments = passFulfillment ? [{ ...passFulfillment }] : [];
+			
+			const quote = createQuoteFromItems([passItemWithQuantity]);
+			
+			existingPayload.message.order.items = [passItemWithQuantity];
+			existingPayload.message.order.fulfillments = fulfillments;
+			existingPayload.message.order.quote = quote;
+			return existingPayload;
+		}
+	}
+	
+	// Standard SJT/RJT flow logic
 	let items = filterItemsBySelectedIds(
 		sessionData.items,
 		sessionData.selected_item_ids

--- a/src/config/mock-config/TRV11/METRO/2.0.0/select/generator.ts
+++ b/src/config/mock-config/TRV11/METRO/2.0.0/select/generator.ts
@@ -42,6 +42,22 @@ const transformToItemFormat = (items: any[]): any => {
 	}
 };
 export async function selectGenerator(existingPayload: any, sessionData: any) {
+	// Detect Monthly Pass flow
+	const isPassFlow = sessionData.flowId === "ORDER_TO_CONFIRM_MONTHLY_PASS";
+	
+	if (isPassFlow) {
+		// For Pass flow, force select I3 with count 1
+		existingPayload.message.order.items = [{
+			id: "I3",
+			quantity: { selected: { count: 1 } }
+		}];
+		if (sessionData.provider_id) {
+			existingPayload.message.order.provider.id = sessionData.provider_id;
+		}
+		return existingPayload;
+	}
+	
+	// Standard SJT/RJT flow logic
 	const items = sessionData?.items;
 	const items_min_max = transformToItemFormat(items);
 	const chosen_items = getRandomItemsWithQuantities(items_min_max);

--- a/src/config/mock-config/TRV11/session-types.ts
+++ b/src/config/mock-config/TRV11/session-types.ts
@@ -38,6 +38,7 @@ export interface SessionData {
 	created_at: string
 	update_fulfillment: any[]
 	buyer_side_fulfillment_ids: any[]
+	flowId: string | undefined
 }
 
 export type BecknContext = {


### PR DESCRIPTION
- Add I3 Pass item to on_search2/default.yaml (P30D, C2, F2)
- Add flowId detection to select/generator.ts for I3 selection
- Add flowId detection to on_select/generator.ts for Pass handling
- Add flowId detection to on_confirm/generator.ts for P30D validity
- Add flowId property to SessionData type