### PR TITLE
fix(TRV11-METRO): Fix Flow 2 empty fulfillment_ids error

### DIFF
--- a/src/config/mock-config/TRV11/METRO/2.0.0/on_search/on_search2/default.yaml
+++ b/src/config/mock-config/TRV11/METRO/2.0.0/on_search/on_search2/default.yaml
@@ -77,7 +77,7 @@ message:
               minimum:
                 count: 1
             fulfillment_ids:
-              - F2
+              - F1
             time:
               label: Validity
               duration: P30D

--- a/src/config/mock-config/TRV11/METRO/2.0.0/on_select/generator.ts
+++ b/src/config/mock-config/TRV11/METRO/2.0.0/on_select/generator.ts
@@ -116,8 +116,8 @@ export async function onSelectGenerator(
 				quantity: { selected: { count: 1 } }
 			};
 			
-			// Get F2 fulfillment for Pass
-			const passFulfillment = sessionData.fulfillments.find((f: any) => f.id === "F2");
+			// Get F1 fulfillment for Pass (same as SJT)
+			const passFulfillment = sessionData.fulfillments.find((f: any) => f.id === "F1");
 			const fulfillments = passFulfillment ? [{ ...passFulfillment }] : [];
 			
 			const quote = createQuoteFromItems([passItemWithQuantity]);


### PR DESCRIPTION
- Change I3 Pass item to use F1 instead of F2 (F2 doesn't exist)
- Update on_select generator to look for F1 fulfillment for Pass flow