### PR TITLE
fix(trv13): dynamic payment amounts and remove provider.tags in confirm (#547)

### DIFF
--- a/src/config/mock-config/TRV13/2.0.1/confirm/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.1/confirm/generator.ts
@@ -2,19 +2,63 @@ export async function confirmDefaultGenerator(
   existingPayload: any,
   sessionData: any
 ) {
+  // Get quote total for payment amount calculation
+  const quoteTotal = parseFloat(sessionData?.on_init_quote?.price?.value || "0");
+  const quoteCurrency = sessionData?.on_init_quote?.price?.currency || "INR";
+
   const payments =
     sessionData?.on_init_payments?.[0]?.map((payment: any) => {
+      let updatedPayment = { ...payment };
+      
+      // Update status based on type
       if (payment.type === "PRE-ORDER") {
-        return { ...payment, status: "PAID" };
-      } else {
-        return { ...payment, status: "NOT-PAID" };
+        updatedPayment.status = "PAID";
+        
+        // Update params.amount from quote
+        if (updatedPayment.params && quoteTotal > 0) {
+          // For split payments, calculate based on payment type tags
+          if (payment.tags) {
+            const advDepositTag = payment.tags.find((t: any) => 
+              t.descriptor?.code === "ADV-DEPOSIT"
+            );
+            if (advDepositTag) {
+              // Advance deposit - use amount from quote or keep existing
+              updatedPayment.params.amount = payment.params?.amount || quoteTotal.toFixed(2);
+            }
+          } else {
+            // Single PRE-ORDER payment - use full quote amount
+            updatedPayment.params.amount = quoteTotal.toFixed(2);
+          }
+          updatedPayment.params.currency = quoteCurrency;
+        }
+      } else if (payment.type === "ON-FULFILLMENT" || payment.type === "PART-PAYMENT") {
+        updatedPayment.status = "NOT-PAID";
+        
+        // Calculate remaining amount for ON-FULFILLMENT
+        if (updatedPayment.params && quoteTotal > 0) {
+          const preOrderPayments = (sessionData?.on_init_payments?.[0] || [])
+            .filter((p: any) => p.type === "PRE-ORDER");
+          
+          const paidAmount = preOrderPayments.reduce((sum: number, p: any) => 
+            sum + parseFloat(p.params?.amount || "0"), 0);
+          
+          const remainingAmount = quoteTotal - paidAmount;
+          updatedPayment.params.amount = remainingAmount.toFixed(2);
+          updatedPayment.params.currency = quoteCurrency;
+        }
       }
+      
+      return updatedPayment;
     }) ?? [];
 
   existingPayload.message.order.payments = payments;
 
   existingPayload.message.order.provider.id =
     sessionData?.on_init_provider_id ?? "P1";
+  
+  // Remove provider.tags as per ONDC spec (not needed in confirm)
+  delete existingPayload.message.order.provider.tags;
+  
   existingPayload.message.order.items = sessionData?.on_init_items[0] ?? [];
   existingPayload.message.order.quote = sessionData?.on_init_quote ?? {};
   existingPayload.message.order.billing = sessionData?.on_init_billing ?? {};


### PR DESCRIPTION
Fix 1: Calculate payment amounts dynamically from quote total
- PRE-ORDER payments now use quote.price.value instead of hardcoded amounts
- ON-FULFILLMENT/PART-PAYMENT calculate remaining amount (quote - prepaid)
- Supports both single and split payment scenarios
- Updates currency from quote

Fix 2: Remove provider.tags from confirm payload
- Explicitly delete provider.tags as per ONDC spec
- Provider.tags should only exist in on_search, on_select, on_init
- Confirm payload now spec-compliant

Addresses GitHub issue #547: hardcoded payment amounts and incorrect provider.tags