### PR TITLE
fix(trv13): calculate payment amounts dynamically from quote total in on_select (#547)

### DIFF
--- a/src/config/mock-config/TRV13/2.0.1/confirm/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.1/confirm/generator.ts
@@ -2,53 +2,13 @@ export async function confirmDefaultGenerator(
   existingPayload: any,
   sessionData: any
 ) {
-  // Get quote total for payment amount calculation
-  const quoteTotal = parseFloat(sessionData?.on_init_quote?.price?.value || "0");
-  const quoteCurrency = sessionData?.on_init_quote?.price?.currency || "INR";
-
   const payments =
     sessionData?.on_init_payments?.[0]?.map((payment: any) => {
-      let updatedPayment = { ...payment };
-      
-      // Update status based on type
       if (payment.type === "PRE-ORDER") {
-        updatedPayment.status = "PAID";
-        
-        // Update params.amount from quote
-        if (updatedPayment.params && quoteTotal > 0) {
-          // For split payments, calculate based on payment type tags
-          if (payment.tags) {
-            const advDepositTag = payment.tags.find((t: any) => 
-              t.descriptor?.code === "ADV-DEPOSIT"
-            );
-            if (advDepositTag) {
-              // Advance deposit - use amount from quote or keep existing
-              updatedPayment.params.amount = payment.params?.amount || quoteTotal.toFixed(2);
-            }
-          } else {
-            // Single PRE-ORDER payment - use full quote amount
-            updatedPayment.params.amount = quoteTotal.toFixed(2);
-          }
-          updatedPayment.params.currency = quoteCurrency;
-        }
-      } else if (payment.type === "ON-FULFILLMENT" || payment.type === "PART-PAYMENT") {
-        updatedPayment.status = "NOT-PAID";
-        
-        // Calculate remaining amount for ON-FULFILLMENT
-        if (updatedPayment.params && quoteTotal > 0) {
-          const preOrderPayments = (sessionData?.on_init_payments?.[0] || [])
-            .filter((p: any) => p.type === "PRE-ORDER");
-          
-          const paidAmount = preOrderPayments.reduce((sum: number, p: any) => 
-            sum + parseFloat(p.params?.amount || "0"), 0);
-          
-          const remainingAmount = quoteTotal - paidAmount;
-          updatedPayment.params.amount = remainingAmount.toFixed(2);
-          updatedPayment.params.currency = quoteCurrency;
-        }
+        return { ...payment, status: "PAID" };
+      } else {
+        return { ...payment, status: "NOT-PAID" };
       }
-      
-      return updatedPayment;
     }) ?? [];
 
   existingPayload.message.order.payments = payments;

--- a/src/config/mock-config/TRV13/2.0.1/on_select/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.1/on_select/generator.ts
@@ -93,6 +93,12 @@ export async function onSelectDefaultGenerator(
 
   existingPayload.message.order.quote.price.value = totalPrice.toString();
 
+  // Calculate payment amounts proportionally from dynamic quote total
+  // Original ratio: advance deposit is 2000/3025 of total, remaining is 1025/3025
+  const advanceDepositRatio = 2000 / 3025;
+  const advanceAmount = Math.round(totalPrice * advanceDepositRatio * 100) / 100;
+  const remainingAmount = Math.round((totalPrice - advanceAmount) * 100) / 100;
+
   existingPayload.message.order.payments = [
     {
       id: "pymnt-1",
@@ -153,7 +159,7 @@ export async function onSelectDefaultGenerator(
       ],
       params: {
         currency: "INR",
-        amount: "2000.00",
+        amount: advanceAmount.toFixed(2),
       },
     },
     {
@@ -167,7 +173,7 @@ export async function onSelectDefaultGenerator(
         },
       ],
       params: {
-        amount: "1025.00",
+        amount: remainingAmount.toFixed(2),
         currency: "INR",
       },
     },


### PR DESCRIPTION
Root cause: on_select/generator.ts was hardcoding payment amounts (2000.00, 1025.00) even though quote total was dynamically calculated based on selected quantity.

Fix:
- Calculate advance deposit (pymnt-4) proportionally: totalPrice * (2000/3025)
- Calculate remaining amount (pymnt-5): totalPrice - advanceAmount
- Amounts now correctly reflect selected quantity (e.g., 5 guests = 11025 total)

Cleanup:
- Revert confirm/generator.ts to simple status-only update (amounts now correct at source)

Addresses GitHub issue #547: payment amounts still hardcoded after previous fix attempt