### PR TITLE
fix(trv13): remove params from pymnt-1, pymnt-2, pymnt-3 in on_select (#662)

### DIFF
--- a/src/config/mock-config/TRV13/2.0.0/on_select/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/on_select/generator.ts
@@ -100,10 +100,6 @@ export async function onSelectDefaultGenerator(
     {
       id: "pymnt-1",
       type: "PRE-ORDER",
-      params: {
-        currency: "INR",
-        amount: totalPrice.toFixed(2),
-      },
       tags: [
         {
           descriptor: {
@@ -115,10 +111,6 @@ export async function onSelectDefaultGenerator(
     {
       id: "pymnt-2",
       type: "ON-FULFILLMENT",
-      params: {
-        currency: "INR",
-        amount: totalPrice.toFixed(2),
-      },
       tags: [
         {
           descriptor: {
@@ -130,10 +122,6 @@ export async function onSelectDefaultGenerator(
     {
       id: "pymnt-3",
       type: "PART-PAYMENT",
-      params: {
-        currency: "INR",
-        amount: totalPrice.toFixed(2),
-      },
       tags: [
         {
           descriptor: {


### PR DESCRIPTION
Contract validation shows FULL-PAYMENT and PART-PAYMENT wrapper entries should NOT contain params.amount in on_select — only the actual sub-payments (ADV-DEPOSIT and FINAL-PAYMENT) carry amounts.

Changes:
- pymnt-1 (PRE-ORDER FULL-PAYMENT): removed params.amount = totalPrice
- pymnt-2 (ON-FULFILLMENT FULL-PAYMENT): removed params.amount = totalPrice
- pymnt-3 (PART-PAYMENT LINKED-PAYMENTS): removed params.amount = totalPrice [reported bug]

pymnt-4 (ADV-DEPOSIT) and pymnt-5 (FINAL-PAYMENT) keep their params as per contract.

Ref: Hotel_TRV13_API_Contract_Complete.docx.md lines 2450-2525 Closes GitHub issue #662