### PR TITLE
fix(TRV13/2.0.0): align payments in on_cancel, on_confirm, on_update generators (Issue #662)

### DIFF
--- a/src/config/mock-config/TRV13/2.0.0/on_cancel/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/on_cancel/generator.ts
@@ -13,6 +13,25 @@ export async function onCancelDefaultGenerator(
       short_desc: "No more required",
       long_desc: "Hotel available at lower price",
     };
+
+  // Build REFUNDED payment from the advance deposit (pymnt-4) that was already paid
+  const confirmedPayments: any[] =
+    sessionData?.on_confirm_payments?.[0] ?? [];
+  const advancePayment = confirmedPayments.find(
+    (p: any) => p.id === "pymnt-4"
+  );
+  existingPayload.message.order.payments = [
+    {
+      id: "pymnt-4",
+      type: "PRE-ORDER",
+      status: "REFUNDED",
+      params: {
+        currency: advancePayment?.params?.currency ?? "INR",
+        amount: advancePayment?.params?.amount ?? "0.00",
+      },
+    },
+  ];
+
   existingPayload.message.order.updated_at =
     sessionData?.context?.timestamp ?? new Date().toISOString();
   return existingPayload;

--- a/src/config/mock-config/TRV13/2.0.0/on_confirm/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/on_confirm/generator.ts
@@ -7,8 +7,37 @@ export async function onConfirmDefaultGenerator(
 
   existingPayload.message.order.id = String("ORDER_ID-" + uuidv4().slice(0, 8));
   existingPayload.message.order.status = "ACTIVE";
-  existingPayload.message.order.payments =
-    sessionData?.confirm_payments[0] ?? [];
+
+  // Build the correct 3-payment structure aligned with the contract:
+  // - pymnt-3 (PART-PAYMENT/LINKED): NOT-PAID
+  // - pymnt-4 (PRE-ORDER/ADV-DEPOSIT): PAID — advance deposit collected by BAP
+  // - pymnt-5 (ON-FULFILLMENT/FINAL-PAYMENT): NOT-PAID — to be collected at checkout
+  const onInitPayments: any[] = sessionData?.on_init_payments?.[0] ?? [];
+  const confirmPayments: any[] = sessionData?.confirm_payments?.[0] ?? [];
+  // Extract the transaction_id from the buyer's confirm payment (for pymnt-4)
+  const txnId =
+    confirmPayments.find((p: any) => p.params?.transaction_id)?.params
+      ?.transaction_id ?? "payment-utr-1234";
+
+  existingPayload.message.order.payments = onInitPayments.map((p: any) => {
+    if (p.id === "pymnt-4") {
+      // Advance deposit — now PAID with transaction_id
+      return {
+        ...p,
+        status: "PAID",
+        params: {
+          ...p.params,
+          transaction_id: txnId,
+        },
+      };
+    }
+    if (p.id === "pymnt-5") {
+      // Final payment — still NOT-PAID at confirm stage
+      return { ...p, status: "NOT-PAID" };
+    }
+    // pymnt-3 (PART-PAYMENT linked wrapper) — NOT-PAID
+    return { ...p, status: "NOT-PAID" };
+  });
 
   existingPayload.message.order.provider.id =
     sessionData?.confirm_provider_id ?? "P1";

--- a/src/config/mock-config/TRV13/2.0.0/on_update/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/on_update/generator.ts
@@ -4,8 +4,24 @@ export async function confirmDefaultGenerator(
 ) {
 
   existingPayload.message.order.status = "COMPLETED";
-  existingPayload.message.order.payments =
-    sessionData?.confirm_payments[0] ?? [];
+
+  // Use on_confirm payments (BPP output) — all PAID at update/completion stage
+  // pymnt-5 (ON-FULFILLMENT) additionally gets a time.timestamp
+  const payments =
+    sessionData?.on_confirm_payments?.[0]?.map((item: any) => {
+      if (item.type === "ON-FULFILLMENT") {
+        return {
+          ...item,
+          status: "PAID",
+          time: {
+            timestamp:
+              sessionData?.context?.timestamp ?? new Date().toISOString(),
+          },
+        };
+      }
+      return { ...item, status: "PAID" };
+    }) ?? [];
+  existingPayload.message.order.payments = payments;
 
   existingPayload.message.order.id = sessionData?.on_confirm_orderID ?? "01";
   existingPayload.message.order.provider.id =


### PR DESCRIPTION
- on_cancel: add missing payments array with status REFUNDED for pymnt-4 (advance deposit)
- on_confirm: build correct 3-payment structure from on_init_payments session key
  - pymnt-3 (PART-PAYMENT): NOT-PAID
  - pymnt-4 (PRE-ORDER/ADV-DEPOSIT): PAID + transaction_id from buyer confirm
  - pymnt-5 (ON-FULFILLMENT/FINAL): NOT-PAID
- on_update: switch from confirm_payments (BAP input) to on_confirm_payments (BPP output), mark all PAID, add time.timestamp to ON-FULFILLMENT payment (pymnt-5)