### PR TITLE
fix(TRV13/2.0.0): sync add-on handling across all select/on_select generators

### DIFF
--- a/src/config/mock-config/TRV13/2.0.0/on_select/on_select_1/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/on_select/on_select_1/generator.ts
@@ -20,7 +20,9 @@ export async function onSelectDefaultGenerator(
   // Get selected addon and its price from catalog
   const selectedAddonId = selectItems[0]?.add_ons?.[0]?.id;
   const catalogAddon = catalogItem?.add_ons?.find((a: any) => a.id === selectedAddonId);
-  const addonPrice = Number(catalogAddon?.price?.value ?? "500.00");
+  const addonPrice = selectItems[0]?.add_ons?.some((a: any) => !!a.id)
+    ? Number(catalogAddon?.price?.value ?? "0.00")
+    : 0;
   const addonName = catalogAddon?.descriptor?.short_desc ?? "Accommodation with all meals included";
 
   // Calculate totals
@@ -54,17 +56,23 @@ export async function onSelectDefaultGenerator(
             currency: "INR",
             value: itemPrice.toFixed(2),
           },
-          add_ons: [
-            {
-              id: selectedAddonId ?? "full-board",
-              price: {
-                currency: "INR",
-                value: addonPrice.toFixed(2),
-              },
-            },
-          ],
+          ...(selectItems[0]?.add_ons?.some((a: any) => !!a.id)
+            ? {
+                add_ons: [
+                  {
+                    id: selectedAddonId,
+                    price: {
+                      currency: "INR",
+                      value: addonPrice.toFixed(2),
+                    },
+                  },
+                ],
+              }
+            : {}),
         },
-        title: catalogItem?.descriptor?.name ?? "Deluxe Room accommodation with all meals included",
+        title: selectItems[0]?.add_ons?.some((a: any) => !!a.id)
+          ? (catalogItem?.descriptor?.name ?? "Deluxe Room accommodation with all meals included")
+          : "Deluxe Room accommodation",
         price: {
           currency: "INR",
           value: totalWithAddons.toFixed(2),
@@ -142,13 +150,13 @@ export async function onSelectDefaultGenerator(
               descriptor: {
                 code: "pymnt-4",
               },
-              value: "1",
+              value: advanceDepositAmount,
             },
             {
               descriptor: {
                 code: "pymnt-5",
               },
-              value: "2",
+              value: finalPaymentAmount,
             },
           ],
         },

--- a/src/config/mock-config/TRV13/2.0.0/on_select/on_select_2/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/on_select/on_select_2/generator.ts
@@ -33,18 +33,23 @@ export async function onSelectDefaultGenerator(
             currency: "INR",
             value: "2000.00",
           },
-          add_ons: [
-            {
-              id: selectItems[0]?.add_ons[0]?.id ?? "full-board",
-              price: {
-                currency: "INR",
-                value: "500.00",
-              },
-            },
-          ],
+          ...(selectItems[0]?.add_ons?.some((a: any) => !!a.id)
+            ? {
+                add_ons: [
+                  {
+                    id: selectItems[0]?.add_ons[0]?.id,
+                    price: {
+                      currency: "INR",
+                      value: "500.00",
+                    },
+                  },
+                ],
+              }
+            : {}),
         },
-        title:
-          "Deluxe Room accommodation with all meals included (breakfast, lunch, and dinner)",
+        title: selectItems[0]?.add_ons?.some((a: any) => !!a.id)
+          ? "Deluxe Room accommodation with all meals included (breakfast, lunch, and dinner)"
+          : "Deluxe Room accommodation",
         price: {
           currency: "INR",
           value: "300.00",
@@ -61,7 +66,7 @@ export async function onSelectDefaultGenerator(
         title: "GST @ 12%",
         price: {
           currency: "INR",
-          value: "400",
+          value: "300",
         },
       },
     ],
@@ -86,7 +91,17 @@ export async function onSelectDefaultGenerator(
       breakup.price.value = itemPrice.toString();
       totalPrice += itemPrice;
     } else {
-      totalPrice += Number(breakup.price.value);
+      // Parse percentage from title e.g. "Service Tax @ 9%" → 9
+      const pctMatch = breakup.title?.match(/(\d+(?:\.\d+)?)%/);
+      if (pctMatch) {
+        const taxAmount = Math.round(
+          (totalPrice * Number(pctMatch[1])) / 100
+        );
+        breakup.price.value = taxAmount.toString();
+        totalPrice += taxAmount;
+      } else {
+        totalPrice += Number(breakup.price.value);
+      }
     }
   });
 
@@ -144,13 +159,13 @@ export async function onSelectDefaultGenerator(
               descriptor: {
                 code: "pymnt-4",
               },
-              value: "1",
+              value: advanceDepositAmount,
             },
             {
               descriptor: {
                 code: "pymnt-5",
               },
-              value: "2",
+              value: finalPaymentAmount,
             },
           ],
         },

--- a/src/config/mock-config/TRV13/2.0.0/on_select/on_select_3/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/on_select/on_select_3/generator.ts
@@ -20,7 +20,9 @@ export async function onSelectDefaultGenerator(
   // Get selected addon and its price from catalog
   const selectedAddonId = selectItems[0]?.add_ons?.[0]?.id;
   const catalogAddon = catalogItem?.add_ons?.find((a: any) => a.id === selectedAddonId);
-  const addonPrice = Number(catalogAddon?.price?.value ?? "500.00");
+  const addonPrice = selectItems[0]?.add_ons?.some((a: any) => !!a.id)
+    ? Number(catalogAddon?.price?.value ?? "0.00")
+    : 0;
 
   // Calculate totals
   const baseItemTotal = itemPrice * quantity;
@@ -53,17 +55,23 @@ export async function onSelectDefaultGenerator(
             currency: "INR",
             value: itemPrice.toFixed(2),
           },
-          add_ons: [
-            {
-              id: selectedAddonId ?? "full-board",
-              price: {
-                currency: "INR",
-                value: addonPrice.toFixed(2),
-              },
-            },
-          ],
+          ...(selectItems[0]?.add_ons?.some((a: any) => !!a.id)
+            ? {
+                add_ons: [
+                  {
+                    id: selectedAddonId,
+                    price: {
+                      currency: "INR",
+                      value: addonPrice.toFixed(2),
+                    },
+                  },
+                ],
+              }
+            : {}),
         },
-        title: catalogItem?.descriptor?.name ?? "Deluxe Room accommodation with all meals included",
+        title: selectItems[0]?.add_ons?.some((a: any) => !!a.id)
+          ? (catalogItem?.descriptor?.name ?? "Deluxe Room accommodation with all meals included")
+          : "Deluxe Room accommodation",
         price: {
           currency: "INR",
           value: totalWithAddons.toFixed(2),
@@ -139,13 +147,13 @@ export async function onSelectDefaultGenerator(
               descriptor: {
                 code: "pymnt-4",
               },
-              value: "1",
+              value: advanceDepositAmount,
             },
             {
               descriptor: {
                 code: "pymnt-5",
               },
-              value: "2",
+              value: finalPaymentAmount,
             },
           ],
         },

--- a/src/config/mock-config/TRV13/2.0.0/on_select/on_select_4/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/on_select/on_select_4/generator.ts
@@ -19,7 +19,9 @@ export async function onSelectDefaultGenerator(
   // Get selected addon and its price from catalog
   const selectedAddonId = selectItems[0]?.add_ons?.[0]?.id;
   const catalogAddon = catalogItem?.add_ons?.find((a: any) => a.id === selectedAddonId);
-  const addonPrice = Number(catalogAddon?.price?.value ?? "500.00");
+  const addonPrice = selectItems[0]?.add_ons?.some((a: any) => !!a.id)
+    ? Number(catalogAddon?.price?.value ?? "0.00")
+    : 0;
 
   // Calculate totals
   const baseItemTotal = itemPrice * quantity;
@@ -52,17 +54,23 @@ export async function onSelectDefaultGenerator(
             currency: "INR",
             value: itemPrice.toFixed(2),
           },
-          add_ons: [
-            {
-              id: selectedAddonId ?? "full-board",
-              price: {
-                currency: "INR",
-                value: addonPrice.toFixed(2),
-              },
-            },
-          ],
+          ...(selectItems[0]?.add_ons?.some((a: any) => !!a.id)
+            ? {
+                add_ons: [
+                  {
+                    id: selectedAddonId,
+                    price: {
+                      currency: "INR",
+                      value: addonPrice.toFixed(2),
+                    },
+                  },
+                ],
+              }
+            : {}),
         },
-        title: catalogItem?.descriptor?.name ?? "Deluxe Room accommodation with all meals included",
+        title: selectItems[0]?.add_ons?.some((a: any) => !!a.id)
+          ? (catalogItem?.descriptor?.name ?? "Deluxe Room accommodation with all meals included")
+          : "Deluxe Room accommodation",
         price: {
           currency: "INR",
           value: totalWithAddons.toFixed(2),
@@ -138,13 +146,13 @@ export async function onSelectDefaultGenerator(
               descriptor: {
                 code: "pymnt-4",
               },
-              value: "1",
+              value: advanceDepositAmount,
             },
             {
               descriptor: {
                 code: "pymnt-5",
               },
-              value: "2",
+              value: finalPaymentAmount,
             },
           ],
         },

--- a/src/config/mock-config/TRV13/2.0.0/select/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/select/generator.ts
@@ -25,7 +25,6 @@ export async function selectDefaultGenerator(
             count: 1,
           },
         },
-        add_ons: [{ id: items[0]?.add_ons?.[1]?.id ?? "full-board" }],
       },
     ];
   }

--- a/src/config/mock-config/TRV13/2.0.0/select/select_1/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/select/select_1/generator.ts
@@ -25,7 +25,6 @@ export async function selectDefaultGenerator(
             count: 1,
           },
         },
-        add_ons: [{ id: items[0]?.add_ons?.[1]?.id ?? "full-board" }],
       },
     ];
   }

--- a/src/config/mock-config/TRV13/2.0.0/select/select_2/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/select/select_2/generator.ts
@@ -23,7 +23,6 @@ export async function selectDefaultGenerator(
           count: 1,
         },
       },
-      add_ons: [{ id: items[0]?.add_ons?.[1]?.id ?? "full-board" }],
     },
   ];
   // ...existing code...


### PR DESCRIPTION
1. Remove hardcoded add_ons from select request generators (select, select_1, select_2)
2. addonPrice returns 0 when no add-on selected (on_select_1, on_select_3, on_select_4)
3. Omit add_ons key entirely from breakup when none selected (all on_select generators)
4. LINKED-PAYMENTS list values now use advanceDepositAmount/finalPaymentAmount
5. Fix on_select_2: correct wrong GST value (400->300), add dynamic tax from title %