### PR TITLE
fix(TRV13/2.0.0): remove add_ons passthrough in select/on_select items arrays

### DIFF
--- a/src/config/mock-config/TRV13/2.0.0/on_select/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/on_select/generator.ts
@@ -32,11 +32,14 @@ export async function onSelectDefaultGenerator(
   const gst = Math.round(totalWithAddons * 0.12);
   const totalPrice = totalWithAddons + serviceTax + gst;
 
-  existingPayload.message.order.items = selectItems.map((item: any) => ({
-    id: item.id,
-    add_ons: item.add_ons,
-    payment_ids: [catalogItems[0]?.payment_ids?.[0]],
-  }));
+  existingPayload.message.order.items = selectItems.map((item: any) => {
+    const validAddOns = (item.add_ons ?? []).filter((a: any) => !!a.id);
+    return {
+      id: item.id,
+      ...(validAddOns.length ? { add_ons: validAddOns } : {}),
+      payment_ids: [catalogItems[0]?.payment_ids?.[0]],
+    };
+  });
 
   existingPayload.message.order.quote = {
     price: {

--- a/src/config/mock-config/TRV13/2.0.0/on_select/on_select_1/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/on_select/on_select_1/generator.ts
@@ -32,11 +32,14 @@ export async function onSelectDefaultGenerator(
   const gst = Math.round(totalWithAddons * 0.12);
   const totalPrice = totalWithAddons + serviceTax + gst;
 
-  existingPayload.message.order.items = selectItems.map((item: any) => ({
-    id: item.id,
-    add_ons: item.add_ons,
-    payment_ids: [catalogItems[0]?.payment_ids?.[0]],
-  }));
+  existingPayload.message.order.items = selectItems.map((item: any) => {
+    const validAddOns = (item.add_ons ?? []).filter((a: any) => !!a.id);
+    return {
+      id: item.id,
+      ...(validAddOns.length ? { add_ons: validAddOns } : {}),
+      payment_ids: [catalogItems[0]?.payment_ids?.[0]],
+    };
+  });
 
   existingPayload.message.order.quote = {
     price: {

--- a/src/config/mock-config/TRV13/2.0.0/on_select/on_select_2/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/on_select/on_select_2/generator.ts
@@ -9,11 +9,14 @@ export async function onSelectDefaultGenerator(
   const selectItems = sessionData?.select_items[0] ?? [];
   const on_search_1_item = sessionData?.on_search_1_items[0] ?? [];
 
-  existingPayload.message.order.items = selectItems.map((item: any) => ({
-    id: item.id,
-    add_ons: item.add_ons,
-    payment_ids: [on_search_1_item[0]?.payment_ids[0]],
-  }));
+  existingPayload.message.order.items = selectItems.map((item: any) => {
+    const validAddOns = (item.add_ons ?? []).filter((a: any) => !!a.id);
+    return {
+      id: item.id,
+      ...(validAddOns.length ? { add_ons: validAddOns } : {}),
+      payment_ids: [on_search_1_item[0]?.payment_ids[0]],
+    };
+  });
 
   existingPayload.message.order.quote = {
     price: {

--- a/src/config/mock-config/TRV13/2.0.0/on_select/on_select_3/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/on_select/on_select_3/generator.ts
@@ -31,11 +31,14 @@ export async function onSelectDefaultGenerator(
   const gst = Math.round(totalWithAddons * 0.12);
   const totalPrice = totalWithAddons + serviceTax + gst;
 
-  existingPayload.message.order.items = selectItems.map((item: any) => ({
-    id: item.id,
-    add_ons: item.add_ons,
-    payment_ids: [catalogItems[0]?.payment_ids?.[0]],
-  }));
+  existingPayload.message.order.items = selectItems.map((item: any) => {
+    const validAddOns = (item.add_ons ?? []).filter((a: any) => !!a.id);
+    return {
+      id: item.id,
+      ...(validAddOns.length ? { add_ons: validAddOns } : {}),
+      payment_ids: [catalogItems[0]?.payment_ids?.[0]],
+    };
+  });
 
   existingPayload.message.order.quote = {
     price: {

--- a/src/config/mock-config/TRV13/2.0.0/on_select/on_select_4/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.0/on_select/on_select_4/generator.ts
@@ -30,11 +30,14 @@ export async function onSelectDefaultGenerator(
   const gst = Math.round(totalWithAddons * 0.12);
   const totalPrice = totalWithAddons + serviceTax + gst;
 
-  existingPayload.message.order.items = selectItems.map((item: any) => ({
-    id: item.id,
-    add_ons: item.add_ons,
-    payment_ids: [catalogItems[0]?.payment_ids?.[0]],
-  }));
+  existingPayload.message.order.items = selectItems.map((item: any) => {
+    const validAddOns = (item.add_ons ?? []).filter((a: any) => !!a.id);
+    return {
+      id: item.id,
+      ...(validAddOns.length ? { add_ons: validAddOns } : {}),
+      payment_ids: [catalogItems[0]?.payment_ids?.[0]],
+    };
+  });
 
   existingPayload.message.order.quote = {
     price: {

--- a/src/config/mock-config/TRV13/2.0.0/select/default.yaml
+++ b/src/config/mock-config/TRV13/2.0.0/select/default.yaml
@@ -13,8 +13,6 @@ order:
       quantity:
         selected:
           count: 1
-      add_ons:
-        - id: full-board
   fulfillments:
     - tags:
         - descriptor:

--- a/src/config/mock-config/TRV13/2.0.0/select/select_1/default.yaml
+++ b/src/config/mock-config/TRV13/2.0.0/select/select_1/default.yaml
@@ -13,8 +13,6 @@ order:
       quantity:
         selected:
           count: 1
-      add_ons:
-        - id: full-board
   fulfillments:
     - tags:
         - descriptor:

--- a/src/config/mock-config/TRV13/2.0.0/select/select_2/default.yaml
+++ b/src/config/mock-config/TRV13/2.0.0/select/select_2/default.yaml
@@ -13,8 +13,6 @@ order:
       quantity:
         selected:
           count: 1
-      add_ons:
-        - id: full-board
   fulfillments:
     - tags:
         - descriptor:


### PR DESCRIPTION
1. Remove hardcoded add_ons from select yaml payloads (default, select_1, select_2)
2. Filter invalid add-ons in on_select items mapping (all 5 generators)
   - Use validAddOns = filter(a => grep -n add_ons /Users/sumon/Desktop/workbench/automation-mock-service/src/config/mock-config/TRV13/2.0.0/on_select/generator.ts /Users/sumon/Desktop/workbench/automation-mock-service/src/config/mock-config/TRV13/2.0.0/on_select/on_select_1/generator.ts /Users/sumon/Desktop/workbench/automation-mock-service/src/config/mock-config/TRV13/2.0.0/on_select/on_select_2/generator.ts /Users/sumon/Desktop/workbench/automation-mock-service/src/config/mock-config/TRV13/2.0.0/on_select/on_select_3/generator.ts /Users/sumon/Desktop/workbench/automation-mock-service/src/config/mock-config/TRV13/2.0.0/on_select/on_select_4/generator.ts 2>/dev/nulla.id) to exclude add-ons with no id
   - Omit add_ons key entirely when no valid add-ons present