### PR TITLE
fix: conditional add_ons handling in TRV13 2.0.1 select & on_select

### DIFF
--- a/src/config/mock-config/TRV13/2.0.1/on_select/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.1/on_select/generator.ts
@@ -16,13 +16,16 @@ export async function onSelectDefaultGenerator(
     ?? on_search_5_item[0];
   const itemPrice = Number(catalogItem?.price?.value ?? "2000.00");
 
-  existingPayload.message.order.items = selectItems.map((item: any) => ({
-    id: item.id,
-    add_ons: item.add_ons ?? [],
-    payment_ids: catalogItem?.payment_ids?.[0]
-      ? [catalogItem.payment_ids[0]]
-      : []
-  }));
+  existingPayload.message.order.items = selectItems.map((item: any) => {
+    const itemHasAddOns = Array.isArray(item.add_ons) && item.add_ons.length > 0;
+    return {
+      id: item.id,
+      ...(itemHasAddOns ? { add_ons: item.add_ons } : {}),
+      payment_ids: catalogItem?.payment_ids?.[0]
+        ? [catalogItem.payment_ids[0]]
+        : [],
+    };
+  });
 
   existingPayload.message.order.quote = {
     price: {
@@ -51,7 +54,10 @@ export async function onSelectDefaultGenerator(
                   );
                   return {
                     id: addon.id,
-                    price: catalogAddon?.price ?? { currency: "INR", value: "0.00" },
+                    price: {
+                      currency: catalogAddon?.price?.currency ?? "INR",
+                      value: catalogAddon?.price?.value ?? "0.00",
+                    },
                   };
                 }),
               }

--- a/src/config/mock-config/TRV13/2.0.1/select/generator.ts
+++ b/src/config/mock-config/TRV13/2.0.1/select/generator.ts
@@ -25,6 +25,10 @@ export async function selectDefaultGenerator(
     ? (items.find((i: any) => i.id === userSelectedId) ?? items[0])
     : items[0];
 
+  // Only include add_ons if the incoming SELECT request already has them
+  const incomingAddOns = existingPayload.message.order.items?.[0]?.add_ons;
+  const hasAddOns = Array.isArray(incomingAddOns) && incomingAddOns.length > 0;
+
   existingPayload.message.order.items = [
     {
       id: selectedItem?.id ?? "Accommodation-1",
@@ -34,7 +38,7 @@ export async function selectDefaultGenerator(
           count: 1,
         },
       },
-      add_ons: [{ id: selectedItem?.add_ons?.[1]?.id ?? "full-board" }],
+      ...(hasAddOns ? { add_ons: incomingAddOns } : {}),
     },
   ];
   return existingPayload;


### PR DESCRIPTION
- select: only include add_ons in items if incoming BAP request contains them (removed hardcoded add_ons[1] injection)
- on_select: omit add_ons field entirely from order.items when not present (no more empty array fallback)
- on_select: strip maximum_value from add-on price in quote.breakup (only currency and value sent)